### PR TITLE
ompi_jenkins.sh: Add params to extra_conf variable rather than assign

### DIFF
--- a/jenkins/ompi/ompi_jenkins.sh
+++ b/jenkins/ompi/ompi_jenkins.sh
@@ -140,7 +140,7 @@ echo Running following tests:
 set|grep jenkins_test_
 
 if [ "$jenkins_test_threads" = "yes" ]; then
-    extra_conf="--enable-mpi-thread-multiple --enable-opal-multi-threads"
+    extra_conf="--enable-mpi-thread-multiple --enable-opal-multi-threads $extra_conf"
 fi
 
 


### PR DESCRIPTION
 The commit allows to a user provide custom configure parameters.