### PR TITLE
Fix env_mpi

### DIFF
--- a/jenkins/ompi/env_mpi.c
+++ b/jenkins/ompi/env_mpi.c
@@ -1,15 +1,18 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <mpi.h>
-int main(int argc, char **argv, char **env)
+
+extern char **environ;
+
+int main(int argc, char **argv)
 {
     int i=0;
     char *astr;
     MPI_Init(&argc,&argv);
-    astr=env[i];
+    astr=environ[i];
     while(astr) {
         printf("%s\n",astr);
-        astr=env[++i];
+        astr=environ[++i];
     }
    MPI_Finalize();
 }


### PR DESCRIPTION
The three argument main is a non-standard gnu extension. It does not
work when the environment is changed after main is invoked (which is
the case when using Open MPI). To avoid issues use the POSIX.1
standard environ variable.

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>