### PR TITLE
Revert "Temporary change to amca test"

### DIFF
--- a/jenkins/ompi/ompi_jenkins.sh
+++ b/jenkins/ompi/ompi_jenkins.sh
@@ -370,12 +370,9 @@ function test_tune()
         fi
 
         # check amca param
-        echo "check setting mca_base_env_list in amca file"
         echo "mca_base_env_list=XXX_A=1;XXX_B=2;XXX_C;XXX_D;XXX_E" > $WORKSPACE/test_amca.conf
-        output=$($OMPI_HOME/bin/mpirun -np 2 -am $WORKSPACE/test_amca.conf $abs_path/env_mpi)
-        val=$(echo ${output} | grep ^XXX_ | wc -l)
+        val=$($OMPI_HOME/bin/mpirun -np 2 -am $WORKSPACE/test_amca.conf $abs_path/env_mpi |grep ^XXX_|wc -l)
         if [ $val -ne 10 ]; then
-            echo "amca file test failed. file contents: $(cat $WORKSPACE/test_amca.conf)"
             exit 1
         fi
     fi


### PR DESCRIPTION
Got what I needed and the test is now failing everywhere. Not seeing
this behavior on my system.

This reverts commit bd2442e5f098897cbe4577c467807637e8265766.

@miked-mellanox My mpool rewrite branch is failing very early. Thanks for taking this commit to help find that. I may propose another change if I still can't find the problem.