### PR TITLE
change deprecated mpirun -am option to --tune

### DIFF
--- a/jenkins/ompi/ompi_jenkins.sh
+++ b/jenkins/ompi/ompi_jenkins.sh
@@ -454,7 +454,7 @@ function test_tune()
 
         # check amca param
         echo "mca_base_env_list=XXX_A=1;XXX_B=2;XXX_C;XXX_D;XXX_E" > $WORKSPACE/test_amca.conf
-        val=$($OMPI_HOME/bin/mpirun $mca -np 2 -am $WORKSPACE/test_amca.conf $abs_path/env_mpi |grep ^XXX_|wc -l)
+        val=$($OMPI_HOME/bin/mpirun $mca -np 2 --tune $WORKSPACE/test_amca.conf $abs_path/env_mpi |grep ^XXX_|wc -l)
         if [ $val -ne 10 ]; then
             exit 1
         fi


### PR DESCRIPTION
I'm running into a failure in the mellanox test script after changing some of the list handling code in ompi. I've traced it back to the use of the deprecated "-am" option to specify configuration files. If you use the recommended "--tune" option to specify the configuration file the bug does not occur. Rather the debugging a deprecated option I'm just changing the test at the source by switching to "--tune".