### PR TITLE
OSHMEM: added C11 macro tests

### DIFF
--- a/jenkins/ompi/c11_test.c
+++ b/jenkins/ompi/c11_test.c
@@ -6,7 +6,8 @@
 
 int main(int argc, char** argv)
 {
-#if (OSHMEM_MAJOR_VERSION * 100) + OSHMEM_MINOR_VERSION >= 400
+#if (defined(SHMEM_MAJOR_VERSION) && SHMEM_MAJOR_VERSION >= 1) && \
+    (defined(SHMEM_MINOR_VERSION) && SHMEM_MINOR_VERSION >= 4)
     char *char_ptr = 0;
     double *double_ptr = 0;
     int *int_ptr = 0;

--- a/jenkins/ompi/c11_test.c
+++ b/jenkins/ompi/c11_test.c
@@ -1,0 +1,163 @@
+
+#include <shmem.h>
+#ifdef ENABLE_PSHMEM
+#include <pshmem.h>
+#endif
+
+int main(int argc, char** argv)
+{
+#if (OSHMEM_MAJOR_VERSION * 100) + OSHMEM_MINOR_VERSION >= 400
+    char *char_ptr = 0;
+    double *double_ptr = 0;
+    int *int_ptr = 0;
+    unsigned int *uint_ptr = 0;
+    short *short_ptr = 0;
+    long *long_ptr = 0;
+    unsigned long *ulong_ptr = 0;
+    long long *long_long_ptr = 0;
+    unsigned long long *ulong_long_ptr = 0;
+    float *float_ptr = 0;
+    shmem_ctx_t ctx;
+
+    shmem_p(char_ptr, 0, 0);
+    shmem_p(ctx, char_ptr, 0, 0);
+
+    shmem_g(long_ptr, 0);
+    shmem_g(ctx, long_ptr, 0);
+
+    shmem_put(double_ptr, double_ptr, 0, 0);
+    shmem_put(ctx, double_ptr, double_ptr, 0, 0);
+
+    shmem_get(long_long_ptr, long_long_ptr, 0, 0);
+    shmem_get(ctx, long_long_ptr, long_long_ptr, 0, 0);
+
+    shmem_iput(int_ptr, int_ptr, 0, 0, 0, 0);
+    shmem_iput(ctx, int_ptr, int_ptr, 0, 0, 0, 0);
+
+    shmem_iget(float_ptr, float_ptr, 0, 0, 0, 0);
+    shmem_iget(ctx, float_ptr, float_ptr, 0, 0, 0, 0);
+
+    shmem_put_nbi(short_ptr, short_ptr, 0, 0);
+    shmem_put_nbi(ctx, short_ptr, short_ptr, 0, 0);
+
+    shmem_get_nbi(short_ptr, short_ptr, 0, 0);
+    shmem_get_nbi(ctx, short_ptr, short_ptr, 0, 0);
+
+    shmem_atomic_swap(int_ptr, 0, 0);
+    shmem_atomic_swap(ctx, int_ptr, 0, 0);
+
+    shmem_atomic_set(int_ptr, 0, 0);
+    shmem_atomic_set(ctx, int_ptr, 0, 0);
+
+    shmem_atomic_fetch(int_ptr, 0);
+    shmem_atomic_fetch(ctx, int_ptr, 0);
+
+    shmem_atomic_compare_swap(long_ptr, 0, 0, 0);
+    shmem_atomic_compare_swap(ctx, long_ptr, 0, 0, 0);
+
+    shmem_atomic_fetch_add(long_ptr, 0, 0);
+    shmem_atomic_fetch_add(ctx, long_ptr, 0, 0);
+
+    shmem_atomic_fetch_and(ulong_ptr, 0, 0);
+    shmem_atomic_fetch_and(ctx, ulong_ptr, 0, 0);
+
+    shmem_atomic_fetch_or(ulong_long_ptr, 0, 0);
+    shmem_atomic_fetch_or(ctx, ulong_long_ptr, 0, 0);
+
+    shmem_atomic_fetch_xor(uint_ptr, 0, 0);
+    shmem_atomic_fetch_xor(ctx, uint_ptr, 0, 0);
+
+    shmem_atomic_fetch_inc(int_ptr, 0);
+    shmem_atomic_fetch_inc(ctx, int_ptr, 0);
+
+    shmem_atomic_add(long_ptr, 0, 0);
+    shmem_atomic_add(ctx, long_ptr, 0, 0);
+
+    shmem_atomic_inc(int_ptr, 0);
+    shmem_atomic_inc(ctx, int_ptr, 0);
+
+    shmem_atomic_and(ulong_ptr, 0, 0);
+    shmem_atomic_and(ctx, ulong_ptr, 0, 0);
+
+    shmem_atomic_or(uint_ptr, 0, 0);
+    shmem_atomic_or(ctx, uint_ptr, 0, 0);
+
+    shmem_atomic_xor(ulong_long_ptr, 0, 0);
+    shmem_atomic_xor(ctx, ulong_long_ptr, 0, 0);
+
+    shmem_wait_until(short_ptr, 0, 0);
+    shmem_test(int_ptr, 0, 0);
+
+#ifdef ENABLE_PSHMEM
+    pshmem_p(char_ptr, 0, 0);
+    pshmem_p(ctx, char_ptr, 0, 0);
+
+    pshmem_g(long_ptr, 0);
+    pshmem_g(ctx, long_ptr, 0);
+
+    pshmem_put(double_ptr, double_ptr, 0, 0);
+    pshmem_put(ctx, double_ptr, double_ptr, 0, 0);
+
+    pshmem_get(long_long_ptr, long_long_ptr, 0, 0);
+    pshmem_get(ctx, long_long_ptr, long_long_ptr, 0, 0);
+
+    pshmem_iput(int_ptr, int_ptr, 0, 0, 0, 0);
+    pshmem_iput(ctx, int_ptr, int_ptr, 0, 0, 0, 0);
+
+    pshmem_iget(float_ptr, float_ptr, 0, 0, 0, 0);
+    pshmem_iget(ctx, float_ptr, float_ptr, 0, 0, 0, 0);
+
+    pshmem_put_nbi(short_ptr, short_ptr, 0, 0);
+    pshmem_put_nbi(ctx, short_ptr, short_ptr, 0, 0);
+
+    pshmem_get_nbi(short_ptr, short_ptr, 0, 0);
+    pshmem_get_nbi(ctx, short_ptr, short_ptr, 0, 0);
+
+    pshmem_atomic_swap(int_ptr, 0, 0);
+    pshmem_atomic_swap(ctx, int_ptr, 0, 0);
+
+    pshmem_atomic_set(int_ptr, 0, 0);
+    pshmem_atomic_set(ctx, int_ptr, 0, 0);
+
+    pshmem_atomic_fetch(int_ptr, 0);
+    pshmem_atomic_fetch(ctx, int_ptr, 0);
+
+    pshmem_atomic_compare_swap(long_ptr, 0, 0, 0);
+    pshmem_atomic_compare_swap(ctx, long_ptr, 0, 0, 0);
+
+    pshmem_atomic_fetch_add(long_ptr, 0, 0);
+    pshmem_atomic_fetch_add(ctx, long_ptr, 0, 0);
+
+    pshmem_atomic_fetch_and(ulong_ptr, 0, 0);
+    pshmem_atomic_fetch_and(ctx, ulong_ptr, 0, 0);
+
+    pshmem_atomic_fetch_or(ulong_long_ptr, 0, 0);
+    pshmem_atomic_fetch_or(ctx, ulong_long_ptr, 0, 0);
+
+    pshmem_atomic_fetch_xor(uint_ptr, 0, 0);
+    pshmem_atomic_fetch_xor(ctx, uint_ptr, 0, 0);
+
+    pshmem_atomic_fetch_inc(int_ptr, 0);
+    pshmem_atomic_fetch_inc(ctx, int_ptr, 0);
+
+    pshmem_atomic_add(long_ptr, 0, 0);
+    pshmem_atomic_add(ctx, long_ptr, 0, 0);
+
+    pshmem_atomic_inc(int_ptr, 0);
+    pshmem_atomic_inc(ctx, int_ptr, 0);
+
+    pshmem_atomic_and(ulong_ptr, 0, 0);
+    pshmem_atomic_and(ctx, ulong_ptr, 0, 0);
+
+    pshmem_atomic_or(uint_ptr, 0, 0);
+    pshmem_atomic_or(ctx, uint_ptr, 0, 0);
+
+    pshmem_atomic_xor(ulong_long_ptr, 0, 0);
+    pshmem_atomic_xor(ctx, ulong_long_ptr, 0, 0);
+
+    pshmem_wait_until(short_ptr, 0, 0);
+    pshmem_test(int_ptr, 0, 0);
+#endif
+#endif
+    return 0;
+}

--- a/jenkins/ompi/ompi_jenkins.sh
+++ b/jenkins/ompi/ompi_jenkins.sh
@@ -772,9 +772,10 @@ if [ -n "$JENKINS_RUN_TESTS" ]; then
                 done
                 if [ `which clang` ]; then
                     if [ -f ${OMPI_HOME}/include/pshmem.h ]; then
-                        pshmem_enabled=-DENABLE_PSHMEM
+                        pshmem_def=-DENABLE_PSHMEM
                     fi;
-                    clang ${abs_path}/c11_test.c -std=c11 ${pshmem_enabled} -o /tmp/c11_test -I${OMPI_HOME}/include -L${OMPI_HOME}/lib -loshmem
+                    clang ${abs_path}/c11_test.c -std=c11 ${pshmem_def} -o /tmp/c11_test \
+                          -I${OMPI_HOME}/include -L${OMPI_HOME}/lib -loshmem
                 fi;
             fi
         fi

--- a/jenkins/ompi/ompi_jenkins.sh
+++ b/jenkins/ompi/ompi_jenkins.sh
@@ -770,6 +770,12 @@ if [ -n "$JENKINS_RUN_TESTS" ]; then
                     exe_path=${exe_dir}/$exe
                     (PATH=$OMPI_HOME/bin:$PATH LD_LIBRARY_PATH=$OMPI_HOME/lib:$LD_LIBRARY_PATH oshmem_runner 8 $exe_path)
                 done
+                if [ `which clang` ]; then
+                    if [ -f ${OMPI_HOME}/include/pshmem.h ]; then
+                        pshmem_enabled=-DENABLE_PSHMEM
+                    fi;
+                    clang ${abs_path}/c11_test.c -std=c11 ${pshmem_enabled} -o /tmp/c11_test -I${OMPI_HOME}/include -L${OMPI_HOME}/lib -loshmem
+                fi;
             fi
         fi
 


### PR DESCRIPTION
- test is effective on OSHMEM v4+ only which supports OpenSHMEM v1.4 spec
- on older versions of OSHMEM it just compiles empty source file

Signed-off-by: Sergey Oblomov <sergeyo@mellanox.com>