### PR TITLE
Reverted test to Open MPI 4.0.x behavior.

### DIFF
--- a/jenkins/ompi/ompi_test.sh
+++ b/jenkins/ompi/ompi_test.sh
@@ -537,12 +537,12 @@ function test_tune()
         echo "--mca mca_base_env_list \"XXX_A=1;XXX_B=2;XXX_C;XXX_D;XXX_E\"" > $WORKSPACE/test_tune.conf
         echo "mca_base_env_list=XXX_A=7;XXX_B=8" > $WORKSPACE/test_amca.conf
         val=$($OMPI_HOME/bin/mpirun $mca --np 2 --tune $WORKSPACE/test_tune.conf --am $WORKSPACE/test_amca.conf $abs_path/env_mpi | sed -n -e 's/^XXX_.*=//p' | sed -e ':a;N;$!ba;s/\n/+/g' | bc)
-        # precedence goes left-to-right.
-        # A is first set to 1 in "tune", and then reset to 7 in "amca".
-        # B is first set to 2 in "tune", but then reset to 8 in "amca"
+        # precedence goes right-to-left (changed in master to correct left-to-right).
+        # A is first set to 7 in "amca", and then reset to 1 in "tune".
+        # B is first set to 8 in "amca", but then reset to 2 in "tune"
         # C, D, E are taken from the environment as 3,4,5
-        # return (7+8+3+4+5)*2=54
-        if [ $val -ne 54 ]; then
+        # return (1+2+3+4+5)*2=30
+        if [ $val -ne 30 ]; then
             exit 1
         fi
 


### PR DESCRIPTION
The test has been updated for https://github.com/open-mpi/ompi/pull/7202 in scope of https://github.com/mellanox-hpc/jenkins_scripts/pull/92. PR 7202 is not ported to Open MPI 4.0.x.

Verification (in progress): https://dev.azure.com/mlnx-swx/mellanox-ompi/_build/results?buildId=468&view=results

Signed-off-by: Artem Ryabov <artemry@mellanox.com>