### PR TITLE
Disable mca_base_env_list tests until ompi_schizo is fixed

### DIFF
--- a/jenkins/ompi/ompi_test.sh
+++ b/jenkins/ompi/ompi_test.sh
@@ -218,6 +218,7 @@ function test_tune()
 {
     echo "check if mca_base_env_list parameter is supported in ${OMPI_HOME}"
     val=$("${OMPI_HOME}/bin/ompi_info" --param mca base --level 9 | grep --count mca_base_env_list || true)
+    val=0 #disable all mca_base_env_list tests until ompi schizo is fixed
 
     mca="--mca pml ucx --mca btl ^vader,tcp,openib,uct"
 


### PR DESCRIPTION
Due to prrte changes this option is broken and all PRs are failing in our CI.
Disable all tests with this option until we fix it in ompi schizo component.

Signed-off-by: Tomislav Janjusic <tomislavj@nvidia.com>